### PR TITLE
BLD: Use pkg_check_modules to find portaudio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ install_manifest.txt
 compile_commands.json
 CTestTestfile.cmake
 _deps
+
+.DS_Store

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,5 +15,6 @@ pkg_check_modules(GTKMM gtkmm-4.0)
 # it contains documentation
 # Now the variables GTKMM_INCLUDE_DIRS, GTKMM_LIBRARY_DIRS and GTKMM_LIBRARIES
 # contain what you expect
+pkg_check_modules(PORTAUDIO2 portaudio-2.0)
 
 add_subdirectory(src)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,7 @@
 link_directories(${GTKMM_LIBRARY_DIRS})
+link_directories(${PORTAUDIO2_LIBRARY_DIRS})
 include_directories(${GTKMM_INCLUDE_DIRS})
+include_directories(${PORTAUDIO2_INCLUDE_DIRS})
 
 include_directories(include)
 include_directories(maximilian)
@@ -21,7 +23,7 @@ set_source_files_properties(
 add_dependencies(${PROJECT_NAME} kbi-resource)
 
 target_link_libraries(${PROJECT_NAME} ${GTKMM_LIBRARIES})
-target_link_libraries(${PROJECT_NAME} portaudio)
+target_link_libraries(${PROJECT_NAME} ${PORTAUDIO2_LIBRARIES})
 target_link_libraries(${PROJECT_NAME} pthread)
 if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
     target_link_libraries(${PROJECT_NAME} asound)


### PR DESCRIPTION
Use `pkg_check_modules` to find `PortAudio`. Seems fine on macOS and Arch Linux.